### PR TITLE
Make Saxon::XML::Document a proper wrapper

### DIFF
--- a/lib/saxon/processor.rb
+++ b/lib/saxon/processor.rb
@@ -20,26 +20,46 @@ module Saxon
 
     # @param config [File, String, IO] an open File, or string,
     #   containing a Saxon configuration file
-    def initialize(config = nil)
+    # @return [Saxon::Processor]
+    def self.create(config = nil)
       licensed_or_config_source = false
       if config
         licensed_or_config_source = Saxon::SourceHelper.to_stream_source(config)
       end
-      @processor = S9API::Processor.new(licensed_or_config_source)
+      s9_processor = S9API::Processor.new(licensed_or_config_source)
+      new(s9_processor)
+    end
+
+    # @param [net.sf.saxon.s9api.Processor] s9_processor The Saxon Processor
+    #   instance to wrap
+    def initialize(s9_processor)
+      @s9_processor = s9_processor
     end
 
     # @param input [File, IO, String] the input XSLT file
     # @param opts [Hash] options for the XSLT
     # @return [Saxon::XSLT::Stylesheet] the new XSLT Stylesheet
     def XSLT(input, opts = {})
-      Saxon::XSLT::Stylesheet.new(@processor, input, opts)
+      Saxon::XSLT::Stylesheet.parse(self, input, opts)
     end
 
     # @param input [File, IO, String] the input XML file
     # @param opts [Hash] options for the XML file
-    # @return [Saxon::XSLT::Stylesheet] the new XML Document
+    # @return [Saxon::XML::Document] the new XML Document
     def XML(input, opts = {})
-      Saxon::XML::Document.new(@processor, input, opts)
+      Saxon::XML::Document.parse(self, input, opts)
+    end
+
+    # @return [net.sf.saxon.s9api.Processor] The underlying Saxon processor
+    def to_java
+      @s9_processor
+    end
+
+    # compare equal if the underlying java processor is the same instance for
+    # self and other
+    # @param other object to compare against
+    def ==(other)
+      other.to_java === to_java
     end
   end
 end

--- a/lib/saxon/xml.rb
+++ b/lib/saxon/xml.rb
@@ -14,11 +14,38 @@ module Saxon
   module XML
     # Parse an XML File or String into a Document object
     class Document
-      class << self
-        def new(processor, string_or_io, opts = {})
-          builder = processor.newDocumentBuilder()
-          builder.build(SourceHelper.to_stream_source(string_or_io, opts))
-        end
+      # @param [Saxon::Processor] processor The processor object which should
+      #   be used to build the document
+      # @param [String, File, IO] string_or_io The input XML
+      # @param [Hash] opts (see Saxon::SourceHelper#to_stream_source)
+      # @return [Saxon::XML::Document]
+      def self.parse(processor, string_or_io, opts = {})
+        builder = processor.to_java.newDocumentBuilder()
+        source = SourceHelper.to_stream_source(string_or_io, opts)
+        xdm_document = builder.build(source)
+        new(xdm_document)
+      end
+
+      # @api private
+      def initialize(xdm_document)
+        @xdm_document = xdm_document
+      end
+
+      # @return [net.sf.saxon.s9api.XdmNode] return the underlying Saxon
+      #   document object
+      def to_java
+        @xdm_document
+      end
+
+      # @return [String] return a simple serialisation of the document
+      def to_s
+        @xdm_document.to_s
+      end
+
+      # @return [Saxon::Processor] return the processor used to create this
+      #   document
+      def processor
+        Saxon::Processor.new(@xdm_document.processor)
       end
     end
   end

--- a/spec/saxon/processor_spec.rb
+++ b/spec/saxon/processor_spec.rb
@@ -5,22 +5,26 @@ describe Saxon::Processor do
   let(:xsl_file) { File.open(fixture_path('eg.xsl')) }
 
   context "without configuration" do
-    let(:processor) { Saxon::Processor.new }
+    let(:processor) { Saxon::Processor.create }
 
     it "can make a new XSLT instance" do
       expect(processor.XSLT(xsl_file)).to respond_to(:transform)
     end
 
     it "can make a new XML instance" do
-      expect(processor.XML(xsl_file)).to respond_to(:node_kind)
+      expect(processor.XML(xsl_file)).to be_a(Saxon::XML::Document)
+    end
+
+    it "can return the underlying Saxon Processor" do
+      expect(processor.to_java).to respond_to(:new_xslt_compiler)
     end
   end
 
   context "with a configuration file" do
     it "works, given a valid config XML file" do
-      processor = Saxon::Processor.new(File.open(fixture_path('config.xml')))
+      processor = Saxon::Processor.create(File.open(fixture_path('config.xml')))
 
-      saxon_processor = processor.instance_variable_get(:@processor)
+      saxon_processor = processor.to_java
       configuration = saxon_processor.underlying_configuration
       expect(configuration.xml_version).to eq(11)
     end

--- a/spec/saxon/xml_spec.rb
+++ b/spec/saxon/xml_spec.rb
@@ -1,30 +1,56 @@
 require 'spec_helper'
 require 'saxon/xml'
 
+java_import 'net.sf.saxon.s9api.XdmNodeKind'
+java_import 'net.sf.saxon.s9api.XdmNode'
+
 describe Saxon::XML do
-  let(:processor) { Saxon::Processor.new }
+  let(:processor) { Saxon::Processor.create }
 
   context "parsing a document" do
+    it "returns a Document (wrapper) object" do
+      doc = processor.XML('<input/>')
+      expect(doc.class).to be(Saxon::XML::Document)
+    end
+
+    it "makes the underlying Saxon XDM document available" do
+      doc = processor.XML('<input/>')
+      expect(doc.to_java.class).to be(XdmNode)
+    end
+
     it "can parse a document from a File object" do
-      expect(processor.XML(File.open(fixture_path('eg.xml')))).to respond_to(:getNodeKind)
+      doc = processor.XML(File.open(fixture_path('eg.xml')))
+      expect(doc.to_java.node_kind).to eq(XdmNodeKind::DOCUMENT)
     end
 
     it "can parse a document from a string" do
       xml = File.read(fixture_path('eg.xml'))
-      expect(processor.XML(xml)).to respond_to(:getNodeKind)
+      doc = processor.XML(xml)
+      expect(doc.to_java.node_kind).to eq(XdmNodeKind::DOCUMENT)
     end
 
     it "can parse a document from an IO object" do
       xml = File.read(fixture_path('eg.xml'))
       io = StringIO.new(xml)
-      expect(processor.XML(io)).to respond_to(:getNodeKind)
+      doc = processor.XML(io)
+      expect(doc.to_java.node_kind).to eq(XdmNodeKind::DOCUMENT)
     end
 
     it "can set the system ID of a parsed document" do
       xml = File.read(fixture_path('eg.xml'))
-      doc = processor.XML(xml, system_id: "http://example.org/")
+      doc = processor.XML(xml, system_id: 'http://example.org/')
 
-      expect(doc.get_document_uri.to_s).to eq("http://example.org/")
+      expect(doc.to_java.document_uri.to_s).to eq('http://example.org/')
     end
+  end
+
+  it "can produce a simple serialisation of its content" do
+    doc = processor.XML('<input/>')
+    expect(doc.to_s.strip).to eq('<input/>')
+  end
+
+  it "can return the Saxon::Processor it was created with" do
+    doc = processor.XML('<input/>')
+    expect(doc.processor).to eq(processor)
   end
 end

--- a/spec/saxon/xslt_spec.rb
+++ b/spec/saxon/xslt_spec.rb
@@ -3,7 +3,7 @@ require 'saxon-xslt'
 require 'stringio'
 
 describe Saxon::XSLT do
-  let(:processor) { Saxon::Processor.new }
+  let(:processor) { Saxon::Processor.create }
 
   context "compiling the stylesheet" do
     it "can compile a stylesheet from a File object" do
@@ -29,6 +29,12 @@ describe Saxon::XSLT do
       # The relative path breaks unless the system ID is correctly set
       expect(xslt).to respond_to(:transform)
     end
+
+    it "can compile a stylesheet from a Saxon::XML::Document" do
+      input = processor.XML(File.open(fixture_path('eg.xsl')))
+      xslt = Saxon::XSLT::Stylesheet.new(input)
+      expect(xslt).to respond_to(:transform)
+    end
   end
 
   context "transforming a document" do
@@ -37,7 +43,7 @@ describe Saxon::XSLT do
       let(:xml) { processor.XML(File.open(fixture_path('eg.xml'))) }
 
       it "takes a Document object as input for a transformation" do
-        expect(xsl.transform(xml)).to respond_to(:getNodeKind)
+        expect { xsl.transform(xml) }.not_to raise_error
       end
 
       context "the transform result" do


### PR DESCRIPTION
Saxon::XML::Document was a class that generated
net.sf.saxon.s9api.XdmNode documents instead. Now it's a full wrapper
class that contains that document and can be passed around.

It's used as the return value for XSLT transformations with
Saxon::XSLT::Stylesheet and can also be used as the input for a new
Stylesheet so you can write XSLTs that write XSLTs.

Likewise Saxon::Processor becomes a fuller wrapper: it can expose the
underlying java net.sf.saxon.s9api.Processor instance.

Because XSLTs and Documents to be used together must be created by the
same Processor Saxon::XML::Documents can return a safe-to-use
Saxon::Processor object, and Saxon::Processors can be instantiated from
an s9api.Processor instance (i.e. given a naked s9api.XdmNode)
