### PR TITLE
Fixes #8 - Allows setting default processor manually.

### DIFF
--- a/lib/saxon/processor.rb
+++ b/lib/saxon/processor.rb
@@ -36,6 +36,28 @@ module Saxon
       @s9_processor = s9_processor
     end
 
+    # Set one or more configuration settings for the processor
+    #
+    # @param [Hash] config A hash, the keys of which are configuration
+    #   settings as symbols or strings (e.g. 'lineNumbering', :lineNumbering)
+    #   and the values of which are strings, booleans, or numbers as appropriate
+    # @return [Saxon::Processor] processor The processor config was applied to
+    def set_config(config = {})
+      raise ArgumentError.new("set_config cannot be called with empty config") if config.empty?
+      config.each do |k,v|
+        to_java.setConfigurationProperty("http://saxon.sf.net/feature/#{k}", v)
+      end
+      self
+    end
+
+    # Get value of a configuration setting for a processor
+    #
+    # @param [Symbol, String] prop The name of the property to return the value of
+    # @return [String, Boolean, Numeric] current value for the property
+    def get_config(prop)
+      to_java.getConfigurationProperty("http://saxon.sf.net/feature/#{prop}")
+    end
+
     # @param input [File, IO, String] the input XSLT file
     # @param opts [Hash] options for the XSLT
     # @return [Saxon::XSLT::Stylesheet] the new XSLT Stylesheet

--- a/spec/saxon/processor_spec.rb
+++ b/spec/saxon/processor_spec.rb
@@ -30,6 +30,20 @@ describe Saxon::Processor do
     end
   end
 
+  context "with configuration set post-creation" do
+    it "works, with configuration set and gotten" do
+      processor = Saxon::Processor.create()
+
+      processor.set_config(:linenumbering => true)
+      expect(processor.get_config(:linenumbering)).to eq(true)
+      expect(processor.XML(File.open(fixture_path('eg.xml'))).xpath('/input').line_number).to be > 0
+
+      processor.set_config(:linenumbering => false)
+      expect(processor.get_config(:linenumbering)).to eq(false)
+      expect(processor.XML(File.open(fixture_path('eg.xml'))).xpath('/input').line_number).to eq(-1)
+    end
+  end
+
   context "the default configuration" do
     it "creates a processor on demand" do
       expect(Saxon::Processor.default).to be_a(Saxon::Processor)


### PR DESCRIPTION
Enables user to set the default processor.  Useful in cases where, say, saxon-xslt is wrapped by another Gem, and you want to be able to configure.