### PR TITLE
Add Configuration wrapper class

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Values are evaluated as XPath expressions in context of the document being trans
 that, to pass a string, you must pass an XPath that resolves to a string, i.e. "'You must wrap strings in quotes'" 
 
 ## Saxon version
-`saxon-xslt` 0.6 includes Saxon HE 9.5.1.7
+`saxon-xslt` 0.7 includes Saxon HE 9.5.1.7
 
 ## Differences between Saxon and Nokogiri
 

--- a/lib/saxon/configuration.rb
+++ b/lib/saxon/configuration.rb
@@ -1,0 +1,71 @@
+module Saxon
+  # Wraps the <tt>net.saxon.Configuration</tt> class. See
+  # http://saxonica.com/documentation9.5/javadoc/net/sf/saxon/Configuration.html
+  # for details of what configuration options are available and what values
+  # they accept. See
+  # http://saxonica.com/documentation9.5/javadoc/net/sf/saxon/lib/FeatureKeys.html
+  # for details of the constant names used to access the values
+  class Configuration
+    # @param processor [Saxon::Processor] a Saxon::Processor instance
+    # @return [Saxon::Configuration]
+    def self.create(processor = nil)
+      if processor
+        config = processor.to_java.underlying_configuration
+      else
+        config = Saxon::S9API::Configuration.new
+      end
+      new(config)
+    end
+
+    # @api private
+    # @param config [net.sf.saxon.Configuration] The Saxon Configuration
+    #   instance to wrap
+    def initialize(config)
+      @config = config
+    end
+
+    # Get a configuration option value
+    # See http://saxonica.com/documentation9.5/javadoc/net/sf/saxon/lib/FeatureKeys.html
+    # for details of the available options. Use the constant name as a string
+    # or symbol as the option
+    #
+    # @param option [String, Symbol]
+    # @return [Object] the value of the configuration option
+    # @raise [NameError] if the option name does not exist
+    def [](option)
+      @config.getConfigurationProperty(option_url(option))
+    end
+
+    # Get a configuration option value
+    # See http://saxonica.com/documentation9.5/javadoc/net/sf/saxon/lib/FeatureKeys.html
+    # for details of the available options. Use the constant name as a string
+    # or symbol as the option
+    #
+    # @param option [String, Symbol]
+    # @param value [Object] the value of the configuration option
+    # @return [Object] the value you passed in
+    # @raise [NameError] if the option name does not exist
+    def []=(option, value)
+      @config.setConfigurationProperty(option_url(option), value)
+    end
+
+    # @return [net.sf.saxon.Configuration] The underlying Saxon Configuration
+    def to_java
+      @config
+    end
+
+    private
+
+    def feature_keys
+      @feature_keys ||= Saxon::S9API::FeatureKeys.java_class
+    end
+
+    def option_url(option)
+      feature_keys.field(normalize_option_name(option)).static_value
+    end
+
+    def normalize_option_name(option)
+      option.to_s.upcase
+    end
+  end
+end

--- a/lib/saxon/s9api.rb
+++ b/lib/saxon/s9api.rb
@@ -6,6 +6,8 @@ module Saxon
   # Puts the Saxon Java classes into a sensible namespace
   module S9API
     java_import 'net.sf.saxon.s9api.Processor'
+    java_import 'net.sf.saxon.Configuration'
+    java_import 'net.sf.saxon.lib.FeatureKeys'
     java_import 'net.sf.saxon.s9api.XdmDestination'
     java_import 'net.sf.saxon.s9api.QName'
   end

--- a/lib/saxon/xslt.rb
+++ b/lib/saxon/xslt.rb
@@ -28,13 +28,13 @@ module Saxon
       # Compile a stylesheet from an existing Saxon::XML instance of an XSLT
       # source
       #
-      # @param [Saxon::XML::Document] source the input XSLT as an XML document
+      # @param document [Saxon::XML::Document] the input XSLT as an XML document
       # @return [Saxon::XSLT::Stylesheet] the compiled XSLT stylesheet
       def self.parse_stylesheet_doc(document)
         new(document)
       end
 
-      # @param [Saxon::XML::Document] source the input XSLT as an XML document
+      # @param source [Saxon::XML::Document] the input XSLT as an XML document
       def initialize(source)
         processor = source.processor
         compiler = processor.to_java.new_xslt_compiler()
@@ -48,7 +48,7 @@ module Saxon
       # you need to pass it quoted: `"'string'"`. An unquoted string is an
       # XPath reference into the document being transformed.
       #
-      # @param [Saxon::XML::Document] document the XML Document object to
+      # @param document [Saxon::XML::Document] the XML Document object to
       #   transform
       # @param params [Hash,Array] xsl params to set in the xsl document
       # @return [Saxon::XML::Document] the transformed XML Document
@@ -78,7 +78,7 @@ module Saxon
       # Not the most useful serialiser in the world. Provided for Nokogiri API
       # compatibility
       #
-      # @param [Saxon::XML::Document] document the XML Document object to
+      # @param document [Saxon::XML::Document] the XML Document object to
       #   serialise
       # @return [String] the XML Document serialised to a string
       def serialize(document)

--- a/lib/saxon/xslt/version.rb
+++ b/lib/saxon/xslt/version.rb
@@ -1,5 +1,5 @@
 module Saxon
   module XSLT
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
   end
 end

--- a/spec/saxon/configuration_spec.rb
+++ b/spec/saxon/configuration_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'saxon/configuration'
+require 'saxon/processor'
+
+describe Saxon::Configuration do
+  it "is instantiated from a java Configuration instance" do
+    config = Saxon::Configuration.new(Saxon::S9API::Configuration.new)
+    expect(config).to be_a(Saxon::Configuration)
+  end
+
+  context "creating a new instance safely" do
+    it "can be created without a pre-existing processor" do
+      expect(Saxon::Configuration.create).to be_a(Saxon::Configuration)
+    end
+
+    it "can be created correctly from a Processor" do
+      processor = Saxon::Processor.create
+      expect(Saxon::Configuration.create(processor)).to be_a(Saxon::Configuration)
+    end
+  end
+
+  context "getting and setting options" do
+    let(:config) { Saxon::Configuration.new(Saxon::S9API::Configuration.new) }
+
+    it "can get a configuration option's current value" do
+      expect(config[:line_numbering]).to be(false)
+    end
+
+    it "can set a configuration option to a new value" do
+      config[:line_numbering] = true
+      expect(config[:line_numbering]).to be(true)
+    end
+
+    it "returns the passed-in value when setting an option" do
+      expect(config[:default_country] = 'NO').to eq('NO')
+    end
+
+    it "doesn't allow you to set a non-existent configuration option" do
+      expect { config[:rubbish] = "value" }.to raise_error(NameError)
+    end
+
+    it "doesn't allow you to get a non-existent configuration option" do
+      expect { config[:rubbish] }.to raise_error(NameError)
+    end
+  end
+end

--- a/spec/saxon/processor_spec.rb
+++ b/spec/saxon/processor_spec.rb
@@ -4,7 +4,7 @@ require 'saxon/processor'
 describe Saxon::Processor do
   let(:xsl_file) { File.open(fixture_path('eg.xsl')) }
 
-  context "without configuration" do
+  context "without explicit configuration" do
     let(:processor) { Saxon::Processor.create }
 
     it "can make a new XSLT instance" do
@@ -18,15 +18,25 @@ describe Saxon::Processor do
     it "can return the underlying Saxon Processor" do
       expect(processor.to_java).to respond_to(:new_xslt_compiler)
     end
+
+    it "can return the processor's configuration instance" do
+      expect(processor.config).to be_a(Saxon::Configuration)
+    end
   end
 
-  context "with a configuration file" do
+  context "with explicit configuration" do
     it "works, given a valid config XML file" do
       processor = Saxon::Processor.create(File.open(fixture_path('config.xml')))
 
-      saxon_processor = processor.to_java
-      configuration = saxon_processor.underlying_configuration
-      expect(configuration.xml_version).to eq(11)
+      expect(processor.config[:xml_version]).to eq("1.1")
+    end
+
+    it "works, given a Saxon::Configuration object" do
+      config = Saxon::Configuration.create
+      config[:line_numbering] = true
+      processor = Saxon::Processor.create(config)
+
+      expect(processor.config[:line_numbering]).to be(true)
     end
   end
 


### PR DESCRIPTION
This allows setting / getting configuration options through an
idiomatic ruby API and supports configuration reuse. Hopefully addresses #8 