### PR TITLE
Fixes #11 - set_params handles symbol parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,17 @@ input = Saxon.XML(File.open('/path/to/your.xml'))
 output = transformer.transform(input)
 ```
 
-XSL parameters can be passed to #transform as a flat array of name, value pairs, or as a hash, e.g.
+XSL parameters can be passed to `#transform` as a flat array of `name`, `value` pairs, or as a hash. `name` can be either a string or a symbol, e.g.
 
 ```ruby
 output = transformer.transform(input, ["my-param", "'my-value'",
-                                       "my-other-param", "/take-from@id"])
+                                       :'my-other-param', "/take-from@id"])
 
 # or
 
 output = transformer.transform(input, {"my-param" => "'my-value'",
-                                       "my-other-param" => "/take-from@id"})
+                                       :'my-other-param' => "/select-from@id",
+                                       my_third_param: "'value-again'"})
 ```
 
 For those familiar with the Saxon API, names are passed directly to the QName constructor.

--- a/lib/saxon/xslt.rb
+++ b/lib/saxon/xslt.rb
@@ -91,12 +91,12 @@ module Saxon
         case params
         when Hash
           params.each do |k,v|
-            transformer.setParameter(S9API::QName.new(k), document.xpath(v))
+            transformer.setParameter(S9API::QName.new(k.to_s), document.xpath(v))
           end
         when Array
           params.each_slice(2) do |k,v|
             raise ArgumentError.new("Odd number of values passed as params: #{params}") if v.nil?
-            transformer.setParameter(S9API::QName.new(k), document.xpath(v))
+            transformer.setParameter(S9API::QName.new(k.to_s), document.xpath(v))
           end
         end
       end

--- a/spec/saxon/xslt_spec.rb
+++ b/spec/saxon/xslt_spec.rb
@@ -75,6 +75,14 @@ describe Saxon::XSLT do
           end
         end
 
+        context "using hash params with symbol keys" do
+          let(:result) { xsl.transform(xml, testparam: "'non-default'") }
+
+          it "contains the parameter value string" do
+            expect(result.to_s.strip).to include("non-default")
+          end
+        end
+
         context "using array params" do
           let(:result) { xsl.transform(xml, ["testparam", "'non-default'"]) }
 


### PR DESCRIPTION
As mentioned in issue #11, allows for slightly less verbose parameter passing.