### PR TITLE
Refactor to allow use of non-vendored Saxon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,11 @@ dist: trusty
 sudo: false
 language: ruby
 rvm:
-  - jruby-9.1.9.0
-  - jruby-1.7.26
+  - jruby-9.1.14.0
+  - jruby-1.7.27
 jdk:
-  - oraclejdk9
   - oraclejdk8
   - openjdk7
-  - openjdk6
-matrix:
-  exclude:
-    - rvm: jruby-9.1.9.0
-      jdk: openjdk6
 cache: bundler
 env:
   JDK_VERSION_FOR_CODECLIMATE: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
+dist: trusty
 sudo: false
 language: ruby
-addons:
-  apt:
-    packages:
-      - haveged
 rvm:
   - jruby-9.1.9.0
   - jruby-1.7.26
 jdk:
+  - oraclejdk9
   - oraclejdk8
   - openjdk7
-  - oraclejdk7
   - openjdk6
 matrix:
   exclude:

--- a/lib/saxon/loader.rb
+++ b/lib/saxon/loader.rb
@@ -1,0 +1,83 @@
+require 'pathname'
+require 'java'
+
+module Saxon
+  # A sensible namespace to put Saxon Java classes into
+  module S9API
+  end
+
+  module Loader
+    LOAD_SEMAPHORE = Mutex.new
+
+    class NoJarsError < StandardError
+      def initialize(path)
+        @path = path
+      end
+
+      def to_s
+        "The path ('#{@path}') you supplied for the Saxon .jar files doesn't exist, sorry"
+      end
+    end
+
+    class MissingJarError < StandardError
+      def initialize(path)
+        @path = path
+      end
+
+      def to_s
+        "One of saxon9he.jar, saxon9pe.jar, or saxon9ee.jar must be present in the path ('#{@path}') you supplied, sorry"
+      end
+    end
+
+    def self.main_jar(path)
+      ['saxon9he.jar', 'saxon9pe.jar', 'saxon9ee.jar'].map { |jar| path.join(jar) }.find { |jar| jar.file? }
+    end
+
+    def self.extra_jars(path)
+      optional = ['saxon9-unpack.jar', 'saxon9-sql.jar'].map { |jar| path.join(jar) }.select { |jar| jar.file? }
+      icu = path.children.find { |jar| jar.extname == '.jar' && !jar.basename.to_s.match(/^saxon-icu|^icu4j/).nil? }
+      ([icu] + optional).compact
+    end
+
+    def self.load!(saxon_home = File.expand_path('../../../vendor/saxonica', __FILE__))
+      return false if @saxon_loaded
+      LOAD_SEMAPHORE.synchronize do
+        if Saxon::S9API.const_defined?(:Processor)
+          false
+        else
+          saxon_home = Pathname.new(saxon_home)
+          raise NoJarsError, saxon_home unless saxon_home.directory?
+          jars = [main_jar(saxon_home)].compact
+          raise MissingJarError if jars.empty?
+          jars += extra_jars(saxon_home)
+
+          add_jars_to_classpath!(saxon_home, jars)
+          import_classes_to_namespace!
+
+          @saxon_loaded = true
+          true
+        end
+      end
+    end
+
+    private
+
+    def self.add_jars_to_classpath!(saxon_home, jars)
+      jars.each do |jar|
+        $CLASSPATH << jar.to_s
+      end
+    end
+
+    def self.import_classes_to_namespace!
+      Saxon::S9API.class_eval do
+        java_import 'net.sf.saxon.s9api.Processor'
+        java_import 'net.sf.saxon.Configuration'
+        java_import 'net.sf.saxon.lib.FeatureKeys'
+        java_import 'net.sf.saxon.s9api.XdmNode'
+        java_import 'net.sf.saxon.s9api.XdmNodeKind'
+        java_import 'net.sf.saxon.s9api.XdmDestination'
+        java_import 'net.sf.saxon.s9api.QName'
+      end
+    end
+  end
+end

--- a/lib/saxon/processor.rb
+++ b/lib/saxon/processor.rb
@@ -16,7 +16,7 @@ module Saxon
     # instance
     # @return [Saxon::Processor]
     def self.default
-      @processor ||= create
+      @processor ||= create(Saxon::Configuration.default)
     end
 
     # @param config [File, String, IO, Saxon::Configuration] an open File, or string,
@@ -24,6 +24,7 @@ module Saxon
     #   object
     # @return [Saxon::Processor]
     def self.create(config = nil)
+      Saxon::Loader.load!
       case config
       when nil
         licensed_or_config_source = false

--- a/lib/saxon/s9api.rb
+++ b/lib/saxon/s9api.rb
@@ -1,14 +1,16 @@
-require 'java'
-$CLASSPATH << File.expand_path('../../../vendor/saxonica/saxon9he.jar', __FILE__)
-$CLASSPATH << File.expand_path('../../../vendor/saxonica/saxon9-unpack.jar', __FILE__)
+require 'saxon/loader'
 
 module Saxon
-  # Puts the Saxon Java classes into a sensible namespace
   module S9API
-    java_import 'net.sf.saxon.s9api.Processor'
-    java_import 'net.sf.saxon.Configuration'
-    java_import 'net.sf.saxon.lib.FeatureKeys'
-    java_import 'net.sf.saxon.s9api.XdmDestination'
-    java_import 'net.sf.saxon.s9api.QName'
+    def self.const_missing(name)
+      Saxon::Loader.load!
+      if const_defined?(name)
+        const_get(name)
+      else
+        msg = "uninitialized constant Saxon::S9API::#{name}"
+        e = NameError.new(msg, name)
+        raise e
+      end
+    end
   end
 end

--- a/lib/saxon/xml.rb
+++ b/lib/saxon/xml.rb
@@ -1,4 +1,3 @@
-require 'saxon/s9api'
 require 'saxon/source_helper'
 require 'saxon/processor'
 
@@ -24,8 +23,12 @@ module Saxon
         builder = processor.to_java.newDocumentBuilder()
         source = SourceHelper.to_stream_source(string_or_io, opts)
         xdm_document = builder.build(source)
-        new(xdm_document)
+        new(xdm_document, processor)
       end
+
+      # @return [Saxon::Processor] return the processor used to create this
+      #   document
+      attr_reader :processor
 
       # @param [String] expr The XPath expression to evaluate
       # @return [net.sf.saxon.s9api.XdmValue] return the value, node, or
@@ -35,8 +38,8 @@ module Saxon
       end
 
       # @api private
-      def initialize(xdm_document)
-        @xdm_document = xdm_document
+      def initialize(xdm_document, processor)
+        @xdm_document, @processor = xdm_document, processor
       end
 
       # @return [net.sf.saxon.s9api.XdmNode] return the underlying Saxon
@@ -48,12 +51,6 @@ module Saxon
       # @return [String] return a simple serialisation of the document
       def to_s
         @xdm_document.to_s
-      end
-
-      # @return [Saxon::Processor] return the processor used to create this
-      #   document
-      def processor
-        Saxon::Processor.new(@xdm_document.processor)
       end
     end
   end

--- a/lib/saxon/xml.rb
+++ b/lib/saxon/xml.rb
@@ -12,6 +12,9 @@ module Saxon
 
   module XML
     # Parse an XML File or String into a Document object
+    # @!attribute [r] processor
+    #   @return [Saxon::Processor] return the processor used to create this
+    #     document
     class Document
       # @api private
       # @param [Saxon::Processor] processor The processor object which should

--- a/lib/saxon/xslt.rb
+++ b/lib/saxon/xslt.rb
@@ -1,4 +1,3 @@
-require 'saxon/s9api'
 require 'saxon/source_helper'
 require 'saxon/processor'
 require 'saxon/xml'
@@ -34,9 +33,13 @@ module Saxon
         new(document)
       end
 
+      # @return [Saxon::Processor] return the processor used to create the
+      #   source of this transformer
+      attr_reader :processor
+
       # @param source [Saxon::XML::Document] the input XSLT as an XML document
       def initialize(source)
-        processor = source.processor
+        @processor = source.processor
         compiler = processor.to_java.new_xslt_compiler()
         @xslt = compiler.compile(source.to_java.as_source)
       end
@@ -59,7 +62,7 @@ module Saxon
         transformer.setDestination(output)
         set_params(transformer, document, params)
         transformer.transform
-        Saxon::XML::Document.new(output.getXdmNode)
+        Saxon::XML::Document.new(output.getXdmNode, processor)
       end
 
       # Transform an input document and return the result as a string.

--- a/lib/saxon/xslt.rb
+++ b/lib/saxon/xslt.rb
@@ -13,6 +13,9 @@ module Saxon
 
   module XSLT
     # a Stylesheet transforms input (XML) into output
+    # @!attribute [r] processor
+    #   @return [Saxon::Processor] return the processor used to create the
+    #     source of this transformer
     class Stylesheet
       # @api private
       # @param processor [Saxon::Processor] the Saxon processor object
@@ -33,8 +36,6 @@ module Saxon
         new(document)
       end
 
-      # @return [Saxon::Processor] return the processor used to create the
-      #   source of this transformer
       attr_reader :processor
 
       # @param source [Saxon::XML::Document] the input XSLT as an XML document

--- a/spec/fixtures/cassettes/Saxon_SourceHelper/returning_a_StreamSource/StreamSource_systemId/for_inputs_where_we_can_infer_the_path_or_URI/is_set_to_an_open-uri_d_URI_s_URI.yml
+++ b/spec/fixtures/cassettes/Saxon_SourceHelper/returning_a_StreamSource/StreamSource_systemId/for_inputs_where_we_can_infer_the_path_or_URI/is_set_to_an_open-uri_d_URI_s_URI.yml
@@ -16,26 +16,24 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Accept-Ranges:
-      - bytes
       Cache-Control:
       - max-age=604800
       Content-Type:
       - text/html
       Date:
-      - Sun, 10 Aug 2014 09:37:13 GMT
+      - Thu, 07 Dec 2017 14:55:49 GMT
       Etag:
-      - '"359670651"'
+      - '"359670651+ident"'
       Expires:
-      - Sun, 17 Aug 2014 09:37:13 GMT
+      - Thu, 14 Dec 2017 14:55:49 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (iad/182A)
+      - ECS (dca/532C)
+      Vary:
+      - Accept-Encoding
       X-Cache:
       - HIT
-      X-Ec-Custom-Error:
-      - '1'
       Content-Length:
       - '1270'
     body:
@@ -59,5 +57,5 @@ http_interactions:
         \ or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\"\
         >More information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version:
-  recorded_at: Sun, 10 Aug 2014 09:37:13 GMT
-recorded_with: VCR 2.9.2
+  recorded_at: Thu, 07 Dec 2017 14:55:49 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/Saxon_SourceHelper/returning_a_StreamSource/StreamSource_systemId/for_inputs_where_we_can_infer_the_path_or_URI/overrides_the_inferred_system_ID_if_set_explicitly.yml
+++ b/spec/fixtures/cassettes/Saxon_SourceHelper/returning_a_StreamSource/StreamSource_systemId/for_inputs_where_we_can_infer_the_path_or_URI/overrides_the_inferred_system_ID_if_set_explicitly.yml
@@ -16,26 +16,24 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Accept-Ranges:
-      - bytes
       Cache-Control:
       - max-age=604800
       Content-Type:
       - text/html
       Date:
-      - Sun, 10 Aug 2014 09:52:49 GMT
+      - Thu, 07 Dec 2017 14:55:50 GMT
       Etag:
-      - '"359670651"'
+      - '"359670651+ident"'
       Expires:
-      - Sun, 17 Aug 2014 09:52:49 GMT
+      - Thu, 14 Dec 2017 14:55:50 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (iad/182A)
+      - ECS (dca/53F7)
+      Vary:
+      - Accept-Encoding
       X-Cache:
       - HIT
-      X-Ec-Custom-Error:
-      - '1'
       Content-Length:
       - '1270'
     body:
@@ -59,5 +57,5 @@ http_interactions:
         \ or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\"\
         >More information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version:
-  recorded_at: Sun, 10 Aug 2014 09:52:49 GMT
-recorded_with: VCR 2.9.2
+  recorded_at: Thu, 07 Dec 2017 14:55:50 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/Saxon_SourceHelper/returning_a_StreamSource/for_input_backed_by_an_InputStream/converts_an_open-uri_d_Uri_correctly.yml
+++ b/spec/fixtures/cassettes/Saxon_SourceHelper/returning_a_StreamSource/for_input_backed_by_an_InputStream/converts_an_open-uri_d_Uri_correctly.yml
@@ -16,26 +16,24 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Accept-Ranges:
-      - bytes
       Cache-Control:
       - max-age=604800
       Content-Type:
       - text/html
       Date:
-      - Sun, 10 Aug 2014 09:34:50 GMT
+      - Thu, 07 Dec 2017 14:55:48 GMT
       Etag:
-      - '"359670651"'
+      - '"359670651+ident"'
       Expires:
-      - Sun, 17 Aug 2014 09:34:50 GMT
+      - Thu, 14 Dec 2017 14:55:48 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (iad/182A)
+      - ECS (dca/2454)
+      Vary:
+      - Accept-Encoding
       X-Cache:
       - HIT
-      X-Ec-Custom-Error:
-      - '1'
       Content-Length:
       - '1270'
     body:
@@ -59,7 +57,7 @@ http_interactions:
         \ or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\"\
         >More information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version:
-  recorded_at: Sun, 10 Aug 2014 09:34:50 GMT
+  recorded_at: Thu, 07 Dec 2017 14:55:48 GMT
 - request:
     method: get
     uri: http://example.org/
@@ -76,26 +74,24 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Accept-Ranges:
-      - bytes
       Cache-Control:
       - max-age=604800
       Content-Type:
       - text/html
       Date:
-      - Sun, 10 Aug 2014 09:34:50 GMT
+      - Thu, 07 Dec 2017 14:55:48 GMT
       Etag:
-      - '"359670651"'
+      - '"359670651+ident"'
       Expires:
-      - Sun, 17 Aug 2014 09:34:50 GMT
+      - Thu, 14 Dec 2017 14:55:48 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (iad/182A)
+      - ECS (dca/2454)
+      Vary:
+      - Accept-Encoding
       X-Cache:
       - HIT
-      X-Ec-Custom-Error:
-      - '1'
       Content-Length:
       - '1270'
     body:
@@ -119,5 +115,5 @@ http_interactions:
         \ or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\"\
         >More information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version:
-  recorded_at: Sun, 10 Aug 2014 09:34:50 GMT
-recorded_with: VCR 2.9.2
+  recorded_at: Thu, 07 Dec 2017 14:55:49 GMT
+recorded_with: VCR 2.9.3

--- a/spec/saxon/xml_spec.rb
+++ b/spec/saxon/xml_spec.rb
@@ -1,10 +1,9 @@
 require 'spec_helper'
 require 'saxon/xml'
 
-java_import 'net.sf.saxon.s9api.XdmNodeKind'
-java_import 'net.sf.saxon.s9api.XdmNode'
-
 describe Saxon::XML do
+  XdmNode = Saxon::S9API::XdmNode
+  XdmNodeKind = Saxon::S9API::XdmNodeKind
   let(:processor) { Saxon::Processor.create }
 
   context "parsing a document" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,13 @@ module FixtureHelpers
   end
 end
 
+if ENV['SAXON_PE'] && ['SAXON_LICENSE']
+  require 'saxon/configuration'
+  Saxon::Loader.load! ENV['SAXON_PE']
+  licensed_config = Saxon::Configuration.create_licensed(ENV['SAXON_LICENSE'])
+  Saxon::Configuration.set_licensed_default!(licensed_config)
+end
+
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/cassettes'
   c.hook_into :webmock


### PR DESCRIPTION
Interface is unchanged. There's some experimental stuff for creating a
licensed configuration that will almost certainly break in a later
release. It's additional API, and will not affect existing users so I'm
going to ship it so the person who asked for it can use it.

Exactly how to test the loader stuff with a PE/EE set of JARs is an open question at the moment, and I'll be talking to Saxonica about it. I can run the tests cleanly locally, but not currently in a CI environment.