### PR TITLE
Allow explicit QName params to be passed in

### DIFF
--- a/lib/saxon/xslt.rb
+++ b/lib/saxon/xslt.rb
@@ -91,17 +91,30 @@ module Saxon
 
       private
 
-      def set_params(transformer, document, params)
+      def resolve_q_name(q_name_or_string)
+        case q_name_or_string
+        when S9API::QName
+          q_name_or_string
+        else
+          S9API::QName.new(q_name_or_string.to_s)
+        end
+      end
+
+      def params_as_kv_pairs(params)
         case params
         when Hash
-          params.each do |k,v|
-            transformer.setParameter(S9API::QName.new(k.to_s), document.xpath(v))
-          end
+          params
         when Array
-          params.each_slice(2) do |k,v|
+          params.each_slice(2).map { |k,v|
             raise ArgumentError.new("Odd number of values passed as params: #{params}") if v.nil?
-            transformer.setParameter(S9API::QName.new(k.to_s), document.xpath(v))
-          end
+            [k, v]
+          }
+        end
+      end
+
+      def set_params(transformer, document, params)
+        params_as_kv_pairs(params).each do |k,v|
+          transformer.setParameter(resolve_q_name(k), document.xpath(v))
         end
       end
     end

--- a/lib/saxon/xslt/version.rb
+++ b/lib/saxon/xslt/version.rb
@@ -1,5 +1,5 @@
 module Saxon
   module XSLT
-    VERSION = "0.8.1"
+    VERSION = "0.8.2"
   end
 end

--- a/spec/fixtures/params-eg.xsl
+++ b/spec/fixtures/params-eg.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eg="http://example.org/ns" version="2.0" exclude-result-prefixes="eg">
   <xsl:param name="testparam">default</xsl:param>
+  <xsl:param name="eg:qname-param" select="false()"/>
   <xsl:template match="input">
     <xsl:choose>
       <xsl:when test="$testparam = 'default'">
@@ -17,5 +18,8 @@
         </output>
       </xsl:otherwise>
     </xsl:choose>
+    <xsl:if test="$eg:qname-param">
+      <qname-param/>
+    </xsl:if>
   </xsl:template>
 </xsl:stylesheet>

--- a/spec/saxon/xslt_spec.rb
+++ b/spec/saxon/xslt_spec.rb
@@ -101,7 +101,20 @@ describe Saxon::XSLT do
           let(:result) { xsl.transform(xml, ["testparam", "local-name(/input)"]) }
 
           it "should contain the name of the tag" do
-          expect(result.to_s.strip).to include('Select works')
+            expect(result.to_s.strip).to include('Select works')
+          end
+        end
+
+        context "passing a QName-using param" do
+          let(:result) { xsl.transform(xml, {Saxon::S9API::QName.fromClarkName('{http://example.org/ns}qname-param') =>  "true()"}) }
+
+          it "should not contain the qname-related output when the param isn't passed" do
+            result = xsl.transform(xml)
+            expect(result.to_s.strip).to_not include('<qname-param/>')
+          end
+
+          it "should contain the qname-related outputtag" do
+            expect(result.to_s.strip).to include('<qname-param/>')
           end
         end
       end


### PR DESCRIPTION
You can now pass params whose name is a QName with an explicit NS
attached in to the transformer.

At the moment this is rather crude - you have to directly instantiate
an net.sf.saxon.s9api.QName (exposed as Saxon::S9API::QName) yourself.

I'll look at what a reasonable wrapper interface would be