### PR TITLE
remove VCR fixture cassettes from .gem package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   JDK_VERSION_FOR_CODECLIMATE: oraclejdk8
   JRUBY_OPTS: "--debug"
 before_script:
-  - if [ "$TRAVIS_JDK_VERSION" = "$JDK_VERSION_FOR_CODECLIMATE" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; chmod +x ./cc-test-reporter; fi
+  - if [ "$TRAVIS_JDK_VERSION" = "$JDK_VERSION_FOR_CODECLIMATE" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; chmod +x ./cc-test-reporter; ./cc-test-reporter before-build; fi
 script:
   - bundle exec rspec
   - if [[ "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_JDK_VERSION" = "$JDK_VERSION_FOR_CODECLIMATE" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in saxon-xslt.gemspec
 gemspec
-
-gem 'codeclimate-test-reporter', group: :test, require: nil

--- a/lib/saxon/xslt/version.rb
+++ b/lib/saxon/xslt/version.rb
@@ -1,5 +1,5 @@
 module Saxon
   module XSLT
-    VERSION = "0.8.2"
+    VERSION = "0.8.2.1"
   end
 end

--- a/saxon-xslt.gemspec
+++ b/saxon-xslt.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency('rake', '~> 12.3')
+  gem.add_development_dependency('rake', '~> 11.3')
   gem.add_development_dependency('rspec', '~> 3.0')
   gem.add_development_dependency('vcr', '~> 4.0')
-  gem.add_development_dependency('addressable', '~> 2.5')
-  gem.add_development_dependency('webmock', '~> 3.3')
+  gem.add_development_dependency('addressable', '~> 2.4.0')
+  gem.add_development_dependency('webmock', '~> 2.3.2')
   gem.add_development_dependency('yard', '~> 0.9.12')
   gem.add_development_dependency('simplecov', '~> 0.15')
 end

--- a/saxon-xslt.gemspec
+++ b/saxon-xslt.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = ["MIT", "MPL-1.0"]
   gem.platform      = 'java'
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = `git ls-files`.split($/).reject { |f| f.match(%r{^spec/fixtures/cassettes}) }
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]

--- a/saxon-xslt.gemspec
+++ b/saxon-xslt.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency('rake', '~> 10.1')
+  gem.add_development_dependency('rake', '~> 12.3')
   gem.add_development_dependency('rspec', '~> 3.0')
-  gem.add_development_dependency('vcr', '~> 2.9.2')
-  gem.add_development_dependency('addressable', '~> 2.4.0')
-  gem.add_development_dependency('webmock', '~> 1.18.0')
+  gem.add_development_dependency('vcr', '~> 4.0')
+  gem.add_development_dependency('addressable', '~> 2.5')
+  gem.add_development_dependency('webmock', '~> 3.3')
   gem.add_development_dependency('yard', '~> 0.9.12')
-  gem.add_development_dependency('simplecov', '~> 0.13')
+  gem.add_development_dependency('simplecov', '~> 0.15')
 end


### PR DESCRIPTION
VCR fixtures were unneccessarily being included in the .gem package,
which resulted in very long path names that have been causing some
windows users problems because of the absolute character length limit on
full paths (not just files).

The fixture cassettes themselves are completely unneeded in the packaged
gem - and running the tests will recreate them for anyone interested.

Addresses #17